### PR TITLE
Fix a write on read situation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 2.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- CSRF fix: safe write on read.
+  [gforcada]
 
 2.0.4 (2014-01-27)
 ------------------

--- a/plone/contentrules/engine/assignments.py
+++ b/plone/contentrules/engine/assignments.py
@@ -14,6 +14,8 @@ from plone.contentrules.engine.interfaces import IRuleAssignable
 from plone.contentrules.engine.interfaces import IRuleAssignment
 from plone.contentrules.engine.interfaces import IRuleAssignmentManager
 
+from plone.protect.auto import safeWrite
+
 from BTrees.OOBTree import OOBTree
 
 
@@ -85,6 +87,10 @@ def ruleAssignmentManagerAdapterFactory(context):
     annotations = IAnnotations(context)
     manager = annotations.get(KEY, None)
     if manager is None:
-        manager = annotations[KEY] = RuleAssignmentManager()
+        annotations[KEY] = RuleAssignmentManager()
+        manager = annotations[KEY]
+        # protect both context and its annotations from a write on read error
+        safeWrite(context)
+        safeWrite(context.__annotations__)
 
     return manager


### PR DESCRIPTION
The rule assign manager is initialized as soon as you open the rules tab thus making a write on read.

It's hard to properly fix this as plone.contentrules is mostly the engine and the one that adds/removes/changes the rules is plone.app.contentrules...

Ideas welcome. See a follow up pull request that partially fixes the problem on plone.app.contentrules