### PR TITLE
Fix a write on read situation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Fixes:
 
 - *add item here*
 
+- CSRF fix: safe write on read.
+  [gforcada]
 
 2.0.4 (2014-01-27)
 ------------------

--- a/plone/contentrules/engine/assignments.py
+++ b/plone/contentrules/engine/assignments.py
@@ -16,6 +16,12 @@ from plone.contentrules.engine.interfaces import IRuleAssignmentManager
 
 from BTrees.OOBTree import OOBTree
 
+try:
+    from plone.protect.auto import safeWrite
+except ImportError:
+    def safeWrite(*args):
+        pass
+
 
 def check_rules_with_dotted_name_moved(rule):
     """Migrate on-the-fly added event dotted name
@@ -85,6 +91,10 @@ def ruleAssignmentManagerAdapterFactory(context):
     annotations = IAnnotations(context)
     manager = annotations.get(KEY, None)
     if manager is None:
-        manager = annotations[KEY] = RuleAssignmentManager()
+        annotations[KEY] = RuleAssignmentManager()
+        manager = annotations[KEY]
+        # protect both context and its annotations from a write on read error
+        safeWrite(context)
+        safeWrite(context.__annotations__)
 
     return manager


### PR DESCRIPTION
see plone/buildout.coredev#150

If the context gets its first annotation it need to be marked as
safe to write.

The same goes for the annotations on the object.