### PR TITLE
Fixed deprecation warning for (I)ObjectEvent from zope.component

### DIFF
--- a/news/3130.feature
+++ b/news/3130.feature
@@ -1,0 +1,3 @@
+Fixed deprecation warning for ``IObjectEvent/ObjectEvent`` from ``zope.component``.
+Drops compatibility with Plone 5.0 and earlier.
+[maurits]

--- a/plone/contentrules/README.rst
+++ b/plone/contentrules/README.rst
@@ -69,7 +69,7 @@ adaptable to IExecutable. This should be a multi-adapter from
 (context, element, event).
 
   >>> from plone.contentrules.rule.interfaces import IExecutable
-  >>> from zope.component.interfaces import IObjectEvent
+  >>> from zope.interface.interfaces import IObjectEvent
 
   >>> @implementer(IExecutable)
   ... @adapter(Interface, IMoveToFolderAction, IObjectEvent)
@@ -507,7 +507,7 @@ Event Filtering
 Rule elements can be specific to certain events. To create some event-specific
 rule elements, first import the specific events
 
-  >>> from zope.component.interfaces import IObjectEvent, ObjectEvent
+  >>> from zope.interface.interfaces import IObjectEvent, ObjectEvent
   >>> from zope.lifecycleevent.interfaces import IObjectCreatedEvent, \
   ...                                            IObjectCopiedEvent, \
   ...                                            IObjectModifiedEvent

--- a/plone/contentrules/zcml.rst
+++ b/plone/contentrules/zcml.rst
@@ -24,7 +24,7 @@ Here is how we would register these in ZCML:
     ...         title="Test condition"
     ...         description="A test condition"
     ...         for="*"
-    ...         event="zope.component.interfaces.IObjectEvent"
+    ...         event="zope.interface.interfaces.IObjectEvent"
     ...         addview="test.condition"
     ...         editview="edit"
     ...         schema=".rule.tests.elements.ITestCondition"
@@ -36,7 +36,7 @@ Here is how we would register these in ZCML:
     ...         title="Test action"
     ...         description="A test action"
     ...         for="*"
-    ...         event="zope.component.interfaces.IObjectEvent"
+    ...         event="zope.interface.interfaces.IObjectEvent"
     ...         addview="test.action"
     ...         editview="edit"
     ...         schema=".rule.tests.elements.ITestAction"
@@ -66,7 +66,7 @@ inspect conditions and actions in rules.
     >>> from plone.contentrules.rule.interfaces import IRuleAction
 
     >>> from zope.component import getUtility
-    >>> from zope.component.interfaces import IObjectEvent
+    >>> from zope.interface.interfaces import IObjectEvent
     >>> from plone.contentrules.rule.tests import elements
 
     >>> condition = getUtility(IRuleCondition, name=u"test.condition")

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.0.11.dev0'
+version = '2.1.0.dev0'
 
 setup(
     name='plone.contentrules',
@@ -12,8 +12,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "Framework :: Plone",
-        "Framework :: Plone :: 4.3",
-        "Framework :: Plone :: 5.0",
         "Framework :: Plone :: 5.1",
         "Framework :: Plone :: 5.2",
         "Framework :: Plone :: Core",
@@ -22,7 +20,6 @@ setup(
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Only in readme and tests.
Drops compatibility with Plone 4.3 and 5.0.