### PR TITLE
Fix fields in the IRuleConfiguration interface

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,15 @@ Changelog
 
 .. towncrier release notes start
 
+2.1.1 (2020-10-09)
+-------------------
+
+Bug fixes:
+
+
+- Fix fields in the interface IRuleConfiguration: enabled, stop and cascading are not required. [andreesg]
+
+
 2.1.0 (2020-09-07)
 ------------------
 

--- a/plone/contentrules/rule/interfaces.py
+++ b/plone/contentrules/rule/interfaces.py
@@ -113,15 +113,18 @@ class IRuleConfiguration(Interface):
 
     enabled = schema.Bool(title = _(u'Enabled'),
                           description = _(u'Whether or not the rule is currently enabled'),
-                          default = True)
+                          default = True,
+                          required = False)
 
     stop = schema.Bool(title = _(u"Stop executing rules"),
                        description = _(u"Whether or not execution of further rules should stop after this rule is executed"),
-                       default = False)
+                       default = False,
+                       required = False)
 
     cascading = schema.Bool(title = _(u"Cascading rule"),
                        description = _(u"Whether or not other rules should be triggered by the actions launched by this rule. Activate this only if you are sure this won't create infinite loops."),
-                       default = False)
+                       default = False,
+                       required = False)
 
 
 class IRule(IContained, IRuleConfiguration):


### PR DESCRIPTION
Based on the changes in https://github.com/plone/plone.app.contentrules/pull/58:
- It was not possible to create a rule without checking the boxes "enabled", "stop" and "cascading"

Changes to the IRuleConfiguration:
- Fields "enabled", "stop" and "cascading" are not required
