### PR TITLE
Replace deprecated zope.container imports with their canonical locations

### DIFF
--- a/news/1.bugfix
+++ b/news/1.bugfix
@@ -1,0 +1,2 @@
+Replace deprecated zope.container imports with their canonical locations.
+[maurits]

--- a/plone/contentrules/README.rst
+++ b/plone/contentrules/README.rst
@@ -387,7 +387,7 @@ have sensible names.
 
 Before a rule is saved, it has no name, and no parent.
 
-  >>> from zope.container.interfaces import IContained
+  >>> from zope.location.interfaces import IContained
   >>> IContained.providedBy(testRule)
   True
   >>> testRule.__name__ is None

--- a/plone/contentrules/engine/assignments.py
+++ b/plone/contentrules/engine/assignments.py
@@ -10,9 +10,9 @@ from zope.annotation.interfaces import IAnnotations
 from zope.component import adapter
 from zope.component import queryUtility
 from zope.container.contained import Contained
-from zope.container.interfaces import IObjectAddedEvent
 from zope.container.ordered import OrderedContainer
 from zope.interface import implementer
+from zope.lifecycleevent.interfaces import IObjectAddedEvent
 
 
 try:

--- a/plone/contentrules/engine/interfaces.py
+++ b/plone/contentrules/engine/interfaces.py
@@ -1,10 +1,10 @@
 from zope import schema
 from zope.annotation.interfaces import IAttributeAnnotatable
 from zope.container.constraints import contains
-from zope.container.interfaces import IContained
 from zope.container.interfaces import IContainerNamesContainer
 from zope.container.interfaces import IOrderedContainer
 from zope.interface import Interface
+from zope.location.interfaces import IContained
 
 
 class StopRule(Exception):

--- a/plone/contentrules/rule/interfaces.py
+++ b/plone/contentrules/rule/interfaces.py
@@ -5,9 +5,9 @@ __docformat__ = "restructuredtext"
 from plone.contentrules import PloneMessageFactory as _
 from zope import schema
 from zope.configuration import fields as configuration_fields
-from zope.container.interfaces import IContained
 from zope.interface import Interface
 from zope.interface.interfaces import IInterface
+from zope.location.interfaces import IContained
 
 
 class IRuleElementData(Interface):


### PR DESCRIPTION
Could actually  have been done in Plone 5.2 already, but is certainly safe now that master is Plone 6 only.